### PR TITLE
Implement order of operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,10 @@ To run the generated `.jar` file, use
 ```
 java -jar target/seeyoul8r-<version>.jar
 ```
-The on-screen buttons should be used to input the desired calculation. The input is evaluated when the "=" button is clicked. The "CLEAR" button clears the input and output ready for the next calculation.
+The on-screen buttons should be used to input the desired calculation. The input is evaluated when the "=" button is clicked. The "CLEAR" button clears the input and output ready for the next calculation. The "ANS" button copies the last evaluated answer to the input field.
 
-Currently, the calculator only supports inputs with one mathematical operation, and is limited to integer (whole-number) calculations.
+Currently, the calculator observes order of operations for addition, subtraction, multiplication and division, but does not include support for brackets or exponentiation, and is limited to integer (whole-number) calculations.
+
 
 # Contribute
 
@@ -33,4 +34,6 @@ See [guide for contributors](CONTRIBUTING).
 
 Made available under MIT License (see [LICENSE](LICENSE)).
 
+# Acknowledgments
 
+The approach used to parse the input and evaluate expressions with multiple binary operators while observing order of operations is based on the discussion in chapters 1-3 of [Let's Build a Compiler, by Jack Crenshaw](https://compilers.iecc.com/crenshaw/).

--- a/src/main/java/com/ejthomas/backend/Parser.java
+++ b/src/main/java/com/ejthomas/backend/Parser.java
@@ -4,13 +4,16 @@ public class Parser {
     
     private String input;
     private boolean evaluated = false;
-    private int pos = 0;
+    private int idx = 0;  // current index in input
+    private char c;  // current character in input
     private int result;
     private boolean errorRaised = false;
     private String lastError;
+    private final String validCharacters = "[0-9+-*/]";
 
     public Parser(String s) {
         input = s;
+        c = input.length() > 0 ? input.charAt(idx): '\0';
     }
 
     public boolean isEvaluated() {
@@ -32,53 +35,26 @@ public class Parser {
             to start by advancing to the next character)
         */
         errorRaised = false;  // overwrite any previous value
-        pos = 0;
-        if (pos == input.length()) {
+        idx = 0;
+        if (idx == input.length()) {
             error("non-empty");
             return;  // exit with error if input is empty
         }
-        char c = input.charAt(pos);
-        int workingResult = getNumber();
-        if (pos == input.length()) {
-            result = workingResult;
-            evaluated = true;
-            return;
-        }
-        c = input.charAt(pos);
-        switch (c) {
-            // AddOps
-            case '+':
-                c = nextChar();
-                workingResult = add(workingResult);
-                break;
-            case '-':
-                c = nextChar();
-                workingResult = sub(workingResult);
-                break;
-            // MulOps
-            case '*':
-                c = nextChar();
-                workingResult = mul(workingResult);
-                break;
-            case '/':
-                c = nextChar();
-                workingResult = div(workingResult);
-                break;
-            default:
-                error("[+-*/]");
-                return;
-        }
-        if (pos == input.length()) {
+        int workingResult = getExpression();
+        // Check that end is reached rejects trailing characters
+        if (idx == input.length() && !errorRaised) {
             evaluated = true;
             result = workingResult;
+        } else {
+            error(validCharacters);
         }
     }
 
-    private char nextChar() {
-        if (++pos < input.length()) {
-            return input.charAt(pos);
+    private void nextChar() {
+        if (++idx < input.length()) {
+            c = input.charAt(idx);
         } else {
-            return '\0';
+            c = '\0';
         }
     }
 
@@ -94,21 +70,73 @@ public class Parser {
         return c == '*' || c == '/';
     }
 
+    private int getExpression() {
+        int expression = getTerm();
+        // This check feels very wrong
+        // if (pos == input.length()) {
+        //     // result = workingResult;
+        //     // evaluated = true;
+        //     return expression;
+        // }
+        if (idx < input.length()) {
+            // char c = input.charAt(idx);
+            while (isAddOp(c)) {
+                if (c == '+') {
+                    nextChar();
+                    expression = add(expression);
+                } else {
+                    nextChar();
+                    expression = sub(expression);
+                }
+            }
+        }
+        return expression;
+    }
+
+    private int getTerm() {
+        /* A term is an expression which can be an operand of the
+         * add/subtract operators. This includes numbers and
+         * binary expressions containing MulOps and factors.
+         */
+        int term = getFactor();
+        if (idx < input.length()) {
+            while (isMulOp(c)) {
+                if (c == '*') {
+                    nextChar();
+                    term = mul(term);
+                } else {
+                    nextChar();
+                    term = div(term);
+                }
+            }
+        } 
+        return term;
+    }
+
+    private int getFactor() {
+        /* A factor is a valid operand of the multiply/divide 
+         * operators. This only includes numbers for the
+         * currently included operation set.
+         */
+        return getNumber();
+    }
+
     private int getNumber() {
-        char c = input.charAt(pos);
+        // char c = input.charAt(idx);
         // Handle sign if present
         if (c == '+') {
             // Skip with no action
-            c = nextChar();
+            nextChar();
         } else if (c == '-') {
-            c = nextChar();
+            nextChar();
             return sub(0); // return 0 - <numerical part>
         }
         // Get numerical part
         if (isDigit(c)) {
-            int initPos = pos;
-            while (isDigit(nextChar())) {}
-            return Integer.parseInt(input.substring(initPos, pos));
+            int initIdx = idx;
+            nextChar();
+            while (isDigit(c)) { nextChar(); }
+            return Integer.parseInt(input.substring(initIdx, idx));
         } else {
             error("[0-9]");
             return 0;
@@ -116,19 +144,19 @@ public class Parser {
     }
 
     private int add(int num1) {
-        return num1 + getNumber();
+        return num1 + getTerm();
     }
 
     private int sub(int num1) {
-        return num1 - getNumber();
+        return num1 - getTerm();
     }
 
     private int mul(int num1) {
-        return num1 * getNumber();
+        return num1 * getFactor();
     }
 
     private int div(int num1) {
-        return num1 / getNumber();
+        return num1 / getFactor();
     }
 
     private void error(String expected) {

--- a/src/main/java/com/ejthomas/frontend/Window.java
+++ b/src/main/java/com/ejthomas/frontend/Window.java
@@ -49,7 +49,7 @@ public class Window extends JFrame {
 
         this.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
         this.pack();
-        this.setSize(400, 400);
+        this.setSize(500, 400);
         this.setResizable(false);
     }
 

--- a/src/test/java/com/ejthomas/backend/ParserTest.java
+++ b/src/test/java/com/ejthomas/backend/ParserTest.java
@@ -43,64 +43,64 @@ public class ParserTest {
         // Add
         Parser parser = new Parser("123+13");
         parser.evaluate();
-        Assertions.assertEquals(true, parser.isEvaluated());
+        Assertions.assertTrue(parser.isEvaluated());
         Assertions.assertEquals(136, parser.getResult());
 
         // Subtract
         parser = new Parser("52-30");
         parser.evaluate();
-        Assertions.assertEquals(true, parser.isEvaluated());
+        Assertions.assertTrue(parser.isEvaluated());
         Assertions.assertEquals(22, parser.getResult());
 
         // Multiply
         parser = new Parser("4*16");
         parser.evaluate();
-        Assertions.assertEquals(true, parser.isEvaluated());
+        Assertions.assertTrue(parser.isEvaluated());
         Assertions.assertEquals(64, parser.getResult());
 
         // Exact divide
         parser = new Parser("34/2");
         parser.evaluate();
-        Assertions.assertEquals(true, parser.isEvaluated());
+        Assertions.assertTrue(parser.isEvaluated());
         Assertions.assertEquals(17, parser.getResult());
 
         // Rounding towards zero divide
         parser = new Parser("49/2");
         parser.evaluate();
-        Assertions.assertEquals(true, parser.isEvaluated());
+        Assertions.assertTrue(parser.isEvaluated());
         Assertions.assertEquals(24, parser.getResult());
 
         // Rejects letter at start
         parser = new Parser("A2/2");
         parser.evaluate();
-        Assertions.assertEquals(false, parser.isEvaluated());
+        Assertions.assertFalse(parser.isEvaluated());
 
         // Rejects letter at end
         parser = new Parser("1+1h");
         parser.evaluate();
-        Assertions.assertEquals(false, parser.isEvaluated());
+        Assertions.assertFalse(parser.isEvaluated());
 
         // Rejects letter as first operand
         parser = new Parser("a*5");
         parser.evaluate();
-        Assertions.assertEquals(false, parser.isEvaluated());
+        Assertions.assertFalse(parser.isEvaluated());
 
         // Rejects letter as second operand
         parser = new Parser("1-c");
         parser.evaluate();
-        Assertions.assertEquals(false, parser.isEvaluated());
+        Assertions.assertFalse(parser.isEvaluated());
 
         // Rejects unsupported operator
         parser = new Parser("2^5");
         parser.evaluate();
-        Assertions.assertEquals(false, parser.isEvaluated());
+        Assertions.assertFalse(parser.isEvaluated());
     }
 
     @Test
     public void givenEmptyString_whenEvaluate_thenExitsGracefully() {
         Parser parser = new Parser("");
         parser.evaluate();
-        Assertions.assertEquals(false, parser.isEvaluated());
+        Assertions.assertFalse(parser.isEvaluated());
     }
 
     @Test
@@ -121,4 +121,40 @@ public class ParserTest {
         Assertions.assertEquals(24, parser.getResult());
     }
 
+    @Test
+    public void givenTermAndFactor_whenEvaluate_thenPrecedenceCorrect() {
+        // Add and multiply, higher precedence 2nd
+        Parser parser = new Parser("1+2*3");
+        parser.evaluate();
+        Assertions.assertTrue(parser.isEvaluated());
+        Assertions.assertEquals(7, parser.getResult());
+
+        // Subtract and divide, higher precedence 2nd
+        parser = new Parser("34-12/4");
+        parser.evaluate();
+        Assertions.assertTrue(parser.isEvaluated());
+        Assertions.assertEquals(31, parser.getResult());
+
+        // Subtract and multiply, higher precedence 1st
+        parser = new Parser("2*15-3");
+        parser.evaluate();
+        Assertions.assertTrue(parser.isEvaluated());
+        Assertions.assertEquals(27, parser.getResult());
+    }
+
+    @Test
+    public void givenThreeTerms_whenEvaluate_thenPrecedenceCorrect() {
+        Parser parser = new Parser("84-2+7");
+        parser.evaluate();
+        Assertions.assertTrue(parser.isEvaluated());
+        Assertions.assertEquals(89, parser.getResult());
+    }
+
+    @Test
+    public void givenThreeFactors_whenEvaluate_thenPrecedenceCorrect() {
+        Parser parser = new Parser("3*4/6");
+        parser.evaluate();
+        Assertions.assertTrue(parser.isEvaluated());
+        Assertions.assertEquals(2, parser.getResult());
+    }
 }

--- a/src/test/java/com/ejthomas/frontend/WindowTest.java
+++ b/src/test/java/com/ejthomas/frontend/WindowTest.java
@@ -36,8 +36,15 @@ public class WindowTest {
     @Test
     public void equalsAction() {
         Window window = new Window("Window");
+
+        // Syntax error if empty
         window.equalsAction();
         Assertions.assertEquals("Syntax Error", window.getAnswer());
+
+        // Sets answer correctly when input field valid
+        window.setInput("15*2");
+        window.equalsAction();
+        Assertions.assertEquals("30", window.getAnswer());
     }
 
     @Test


### PR DESCRIPTION
Closes #3 

Expressions of the form "1+2\*3" are now evaluated according to the mathematical order of operations rule, specifying that addition and subtraction are performed after multiplication and division. When parsed in this way, the previous example is equivalent to "1+(2\*3)" and not "(1+2)\*3".