### PR TITLE
Integer exponentiation supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ java -jar target/seeyoul8r-<version>.jar
 ```
 The on-screen buttons should be used to input the desired calculation. The input is evaluated when the "=" button is clicked. The "CLEAR" button clears the input and output ready for the next calculation. The "ANS" button copies the last evaluated answer to the input field.
 
-Currently, the calculator observes order of operations for parentheses, addition, subtraction, multiplication and division, but does not include support for exponentiation, and is limited to integer (whole-number) calculations.
+Currently, the calculator observes order of operations for parentheses, powers, addition, subtraction, multiplication and division, but is limited to integer (whole-number) calculations.
 
 
 # Contribute

--- a/src/main/java/com/ejthomas/backend/Calculator.java
+++ b/src/main/java/com/ejthomas/backend/Calculator.java
@@ -1,58 +1,44 @@
 package com.ejthomas.backend;
 
-import java.util.HashSet;
-import java.util.Collections;
-import java.util.LinkedList;
-
 public class Calculator {
-    public static void main(String[] args) {
-        // Receive input from frontend -- provided as String
-        String input = "1++2";
 
-        Parser parser = new Parser(input);
-
-        parser.evaluate();
-
-        if (parser.isEvaluated()) {
-            System.out.print(input + "=" + parser.getResult() + "\n");
-        }
+    public static int pow(int base, int exponent) {
+        return powBySquaring(base, exponent);
     }
 
-    public static LinkedList<String> toSequence(String s) {
-        LinkedList<String> sequence = new LinkedList<>();
-        HashSet<String> operators = new HashSet<String>();
-        Collections.addAll(operators, "+", "-", "*", "/", "sqrt");
-        int i = 0;
-        while (i < s.length()) {
-            if (Character.isDigit(s.charAt(i))) {
-                // Handle groups of digits
-                int start = i;
-                while (++i < s.length() && Character.isDigit(s.charAt(i))) {}
-                sequence.add(s.substring(start, i));
+    private static int powBySquaring(int base, int exponent) {
+        /*
+         * Cases:
+         * - base and exponent == 0
+         * - base != 0, exponent == 0
+         * - base > 0, exponent < 0
+         * - base == 0, exponent < 0
+         * - exponent > 0
+         */
+        if (exponent == 0) {
+            if (base == 0) {
+                throw new ArithmeticException("0/0 is undefined");
             } else {
-                // Handle operators
-                int start = i;
-                while (++i < s.length() && !Character.isDigit(s.charAt(i))) {}
-                String subs = s.substring(start, i);
-                int j = 0;
-                while (++j <= subs.length()) {
-                    if (operators.contains(subs)) {
-                        sequence.add(subs);
-                        subs = "";
-                    } else {
-                        if (operators.contains(subs.substring(0, j))) {
-                            sequence.add(subs.substring(0, j));
-                            subs = subs.substring(j); // subs.substring(j).length() == 0 if j == subs.length()
-                            j = 0;
-                        }
-                    }
-                }
-                // Check all operators parsed
-                if (subs.length() > 0) {
-                    System.out.println("Error: could not parse operator: " + subs);
-                }
+                return 1;
             }
         }
-        return sequence;
+        if (exponent < 0) {
+            // Throws ArithmeticException for base == 0
+            return powBySquaring(1 / base, -exponent);
+        }
+        // Use tail-recursive iteration
+        return powBySquaringIteration(1, base, exponent);
+    }
+
+    private static int powBySquaringIteration(int carry, int base, int exponent) {
+        if (exponent == 1) {
+            return carry * base;
+        }
+        if (exponent % 2 == 0) {
+            return powBySquaringIteration(carry, base * base, exponent / 2);
+        }
+        // exponent % 2 == 1
+        // This means exponent / 2 == (exponent - 1) / 2
+        return powBySquaringIteration(carry * base, base * base, exponent / 2);
     }
 }

--- a/src/main/java/com/ejthomas/backend/Parser.java
+++ b/src/main/java/com/ejthomas/backend/Parser.java
@@ -72,14 +72,7 @@ public class Parser {
 
     private int getExpression() {
         int expression = getTerm();
-        // This check feels very wrong
-        // if (pos == input.length()) {
-        //     // result = workingResult;
-        //     // evaluated = true;
-        //     return expression;
-        // }
         if (idx < input.length()) {
-            // char c = input.charAt(idx);
             while (isAddOp(c)) {
                 if (c == '+') {
                     nextChar();
@@ -115,33 +108,38 @@ public class Parser {
 
     private int getFactor() {
         /* A factor is a valid operand of the multiply/divide 
-         * operators. This includes numbers and expressions
-         * enclosed in parentheses e.g. (expression).
+         * operators. This includes numbers, numbers raised 
+         * to powers and expressions enclosed in parentheses 
+         * e.g. (expression).
          */
+        int factor;
         if (c == '(') {
             nextChar();
-            int factor = getExpression();
+            factor = getExpression();
             if (c == ')') {
                 nextChar();
-                return factor;
             } else {
                 error(")");
                 return 0;
             }
         } else {
-            return getNumber();
+            factor = getNumber();
         }
+        if (c == '^') {
+            nextChar();
+            factor = pow(factor);
+        }
+        return factor;
     }
 
     private int getNumber() {
-        // char c = input.charAt(idx);
         // Handle sign if present
         if (c == '+') {
             // Skip with no action
             nextChar();
         } else if (c == '-') {
             nextChar();
-            return sub(0); // return 0 - <numerical part>
+            return -getNumber();
         }
         // Get numerical part
         if (isDigit(c)) {
@@ -156,19 +154,28 @@ public class Parser {
     }
 
     private int add(int num1) {
+        // TODO: check for overflow before evaluating
         return num1 + getTerm();
     }
 
     private int sub(int num1) {
+        // TODO: check for overflow before evaluating
         return num1 - getTerm();
     }
 
     private int mul(int num1) {
+        // TODO: check for overflow before evaluating
         return num1 * getFactor();
     }
 
     private int div(int num1) {
+        // TODO: check for overflow before evaluating
         return num1 / getFactor();
+    }
+
+    private int pow(int base) {
+        // TODO: check for overflow before evaluating
+        return Calculator.pow(base, getFactor());
     }
 
     private void error(String expected) {

--- a/src/main/java/com/ejthomas/frontend/Window.java
+++ b/src/main/java/com/ejthomas/frontend/Window.java
@@ -49,7 +49,7 @@ public class Window extends JFrame {
 
         this.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
         this.pack();
-        this.setSize(500, 400);
+        this.setSize(600, 400);
         this.setResizable(false);
     }
 
@@ -72,17 +72,14 @@ public class Window extends JFrame {
     private JPanel createDisplayPanel() {
         JPanel displayPanel = new JPanel();
         displayPanel.setLayout(new BoxLayout(displayPanel, BoxLayout.LINE_AXIS));
-        // this.getContentPane().add(displayPanel, BorderLayout.PAGE_START);
 
         inputField = new JTextField();
-        // tf.setBounds(400, 50, 200, 50);
         inputField.setPreferredSize(new Dimension(100, 50));
         displayPanel.add(inputField);
 
 
         answerLabel = new JLabel();
         answerLabel.setPreferredSize(new Dimension(100, 50));
-        // label.setBounds(400, 150, 200, 50);
         displayPanel.add(answerLabel);
         return displayPanel;
     }
@@ -114,19 +111,19 @@ public class Window extends JFrame {
         operationPanel.setLayout(new GridBagLayout());
         GridBagConstraints gbc = new GridBagConstraints();
 
-        InputButton leftParenButton = new InputButton("(", this);
-        InputButton rightParenButton = new InputButton(")", this);
-        InputButton addButton = new InputButton("+", this);
-        InputButton subButton = new InputButton("-", this);
-        InputButton mulButton = new InputButton("*", this, "x");
-        InputButton divButton = new InputButton("/", this);
-
         JButton clearButton = new JButton("CLEAR");
         clearButton.addActionListener(new ActionListener(){
             public void actionPerformed(ActionEvent e) {
                 clearAction();
             }
         });
+        InputButton powerButton = new InputButton("^", this, "a^b");
+        InputButton leftParenButton = new InputButton("(", this);
+        InputButton rightParenButton = new InputButton(")", this);
+        InputButton addButton = new InputButton("+", this);
+        InputButton subButton = new InputButton("-", this);
+        InputButton mulButton = new InputButton("*", this, "x");
+        InputButton divButton = new InputButton("/", this);
 
         // Global constraints
         gbc.fill = GridBagConstraints.BOTH;
@@ -136,12 +133,17 @@ public class Window extends JFrame {
         // Clear button
         gbc.gridx = 0;
         gbc.gridy = 0;
-        gbc.gridwidth = 2;
-        gbc.weightx = 1;
+        gbc.gridwidth = 1;
+        gbc.weightx = 0.5;
         gbc.weighty = 0.5;
         operationPanel.add(clearButton, gbc);
 
+        // Power button
+        gbc.gridx += 1;
+        operationPanel.add(powerButton, gbc);
+
         // Left parenthesis
+        gbc.gridx = 0;
         gbc.gridy += 1;
         gbc.weightx = 0.5;
         gbc.weighty = 0.5;
@@ -206,6 +208,4 @@ public class Window extends JFrame {
     public void lastAnswerAction() {
         setInput(getInput() + lastAnswer);
     }
-
-    // TODO:extension beyond single operation
 }

--- a/src/test/java/com/ejthomas/backend/CalculatorTest.java
+++ b/src/test/java/com/ejthomas/backend/CalculatorTest.java
@@ -1,5 +1,51 @@
 package com.ejthomas.backend;
 
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
+
 public class CalculatorTest {
-    
+    /*
+     * Functions to test:
+     * - pow()
+     */
+    @Test
+    public void givenPosIntBaseAndExp_whenPow_thenCalculatesPower() {
+        // 1st argument is base, 2nd is exponent
+        Assertions.assertEquals(125, Calculator.pow(5, 3));
+    }
+
+    @Test
+    public void givenZeroExpAndPosIntBase_whenPow_thenReturnOne() {
+        Assertions.assertEquals(1, Calculator.pow(3, 0));
+    }
+
+    @Test
+    public void givenZeroBaseAndPosIntExp_whenPow_thenReturnZero() {
+        Assertions.assertEquals(0, Calculator.pow(0, 6));
+    }
+
+    @Test
+    public void givenZeroBaseAndExp_whenPow_thenThrowsArithmeticException() {
+        Assertions.assertThrows(ArithmeticException.class, ()->Calculator.pow(0, 0));
+    }
+
+    @Test
+    public void givenZeroBaseAndNegativeIntExp_whenPow_thenThrowsArithmeticException() {
+        Assertions.assertThrows(ArithmeticException.class, ()->Calculator.pow(0, -2));
+    }
+
+    @Test
+    public void givenPosIntBaseAndNegativeIntExp_whenPow_thenPerformsIntDivide() {
+        // This is only correct for integer arithmetic
+        Assertions.assertEquals(0, Calculator.pow(2, -1));
+        Assertions.assertEquals(1, Calculator.pow(1, -1));
+        Assertions.assertEquals(1, Calculator.pow(1, -3));
+        Assertions.assertEquals(0, Calculator.pow(3, -2));
+    }
+
+    @Test
+    public void givenNegativeIntBaseAndPositiveIntExp_whenPow_thenCalculatesPower() {
+        Assertions.assertEquals(16, Calculator.pow(-2, 4));
+        Assertions.assertEquals(-27, Calculator.pow(-3, 3));
+    }
 }

--- a/src/test/java/com/ejthomas/backend/ParserTest.java
+++ b/src/test/java/com/ejthomas/backend/ParserTest.java
@@ -91,7 +91,7 @@ public class ParserTest {
         Assertions.assertFalse(parser.isEvaluated());
 
         // Rejects unsupported operator
-        parser = new Parser("2^5");
+        parser = new Parser("2&5");
         parser.evaluate();
         Assertions.assertFalse(parser.isEvaluated());
     }
@@ -189,5 +189,48 @@ public class ParserTest {
         parser = new Parser("1+2)*3");
         parser.evaluate();
         Assertions.assertFalse(parser.isEvaluated());
+    }
+
+    @Test
+    public void givenPower_whenEvaluate_thenAccepts() {
+        Parser parser = new Parser("10^4");
+        parser.evaluate();
+        Assertions.assertEquals(10000, parser.getResult());
+
+        parser = new Parser("2^10");
+        parser.evaluate();
+        Assertions.assertEquals(1024, parser.getResult());
+
+        parser = new Parser("-1^2");
+        parser.evaluate();
+        Assertions.assertEquals(1, parser.getResult());
+
+        parser = new Parser("10^-1");
+        parser.evaluate();
+        Assertions.assertTrue(parser.isEvaluated());
+        Assertions.assertEquals(0, parser.getResult());
+    }
+
+    @Test
+    public void givenExpressionWithPower_whenEvaluate_thenPrecedenceCorrect() {
+        Parser parser = new Parser("(1+2)^2");
+        parser.evaluate();
+        Assertions.assertEquals(9, parser.getResult());
+
+        parser = new Parser("2^(2+2)");
+        parser.evaluate();
+        Assertions.assertEquals(16, parser.getResult());
+
+        parser = new Parser("5*2^2");
+        parser.evaluate();
+        Assertions.assertEquals(20, parser.getResult());
+
+        parser = new Parser("3+4^2-1");
+        parser.evaluate();
+        Assertions.assertEquals(18, parser.getResult());
+
+        parser = new Parser("2^3^2");
+        parser.evaluate();
+        Assertions.assertEquals(512, parser.getResult());
     }
 }


### PR DESCRIPTION
Addresses #8 but missing support for floating point exponentiation, blocked by #9 

The `Calculator` class now provides a static `pow` function to raise a base to the power of an exponent. Only integer arguments are currently supported. A corresponding button on the interface display enables input of the "^" character to represent exponentiation. Order of operations is observed for powers, with the convention that the "^" operator is right-associative, i.e. 2^3^2 == 2^(3^2) and not (2^3)^2.