### PR TITLE
Move to double-precision floating-point calculations

### DIFF
--- a/src/main/java/com/ejthomas/backend/Calculator.java
+++ b/src/main/java/com/ejthomas/backend/Calculator.java
@@ -2,11 +2,22 @@ package com.ejthomas.backend;
 
 public class Calculator {
 
-    public static int pow(int base, int exponent) {
-        return powBySquaring(base, exponent);
+    public final static double EPSILON_REL = 1e-10;
+    public final static int MAX_ITERATIONS = 1_000_000;
+
+    /*
+     * Power function
+     */
+    public static double pow(double base, double exponent) {
+        if (exponent == (int)exponent) {
+            // Exponent is integer
+            return powBySquaring(base, (int)exponent);
+        } else {
+            return powByLogarithm(base, exponent);
+        }
     }
 
-    private static int powBySquaring(int base, int exponent) {
+    private static double powBySquaring(double base, int exponent) {
         /*
          * Cases:
          * - base and exponent == 0
@@ -23,14 +34,16 @@ public class Calculator {
             }
         }
         if (exponent < 0) {
-            // Throws ArithmeticException for base == 0
+            if (base == 0) {
+                throw new ArithmeticException("1/0 is undefined");
+            }
             return powBySquaring(1 / base, -exponent);
         }
         // Use tail-recursive iteration
         return powBySquaringIteration(1, base, exponent);
     }
 
-    private static int powBySquaringIteration(int carry, int base, int exponent) {
+    private static double powBySquaringIteration(double carry, double base, int exponent) {
         if (exponent == 1) {
             return carry * base;
         }
@@ -40,5 +53,108 @@ public class Calculator {
         // exponent % 2 == 1
         // This means exponent / 2 == (exponent - 1) / 2
         return powBySquaringIteration(carry * base, base * base, exponent / 2);
+    }
+
+    private static double powByLogarithm(double base, double exponent) {
+        /*
+         * ln(pow(base, exponent)) == exponent * ln(base)
+         * Therefore pow(base, exponent) == exp(ln(pow(base, exponent)))
+         * pow(base, exponent) == exp(exponent * ln(base))
+         */
+        if (base == 0 && exponent > 0) {
+            return 0;
+        } else if (base < 0 || (base == 0 && exponent <= 0)) {
+            throw new ArithmeticException(String.format("%f^%f is undefined", base, exponent));
+        }
+        return exp(exponent * ln(base));
+    }
+
+    /*
+     * Absolute value
+     */
+    public static double abs(double x) {
+        return x < 0 ? -x : x;
+    }
+
+    /*
+     * Exponential function (e^x)
+     */
+    public static double exp(double x) {
+        if (x < 0) {
+            // Alternating term signs cause slow convergence, overflow
+            // Computing 1/exp(-x) in this case avoids this
+            return 1.0 / exp(-x);
+        }
+        double newTerm = 1;
+        double result = 0;
+        int n = 0;  // term counter
+        while (abs(newTerm) > EPSILON_REL * result) {
+            if (n > MAX_ITERATIONS) {
+                throw new ArithmeticException(String.format("exp(%f) did not converge", x));
+            }
+            result += newTerm;
+            newTerm = expNextTerm(x, ++n, newTerm);
+        }
+        return result + newTerm;
+    }
+
+    private static double expNextTerm(double x, int n, double lastTerm) {
+        /*
+         * exp(x) == sum_(n=1,n=infinity) pow(x, n) / factorial(n)
+         * pow(x, n) / factorial(n) == (pow(x, n - 1) / factorial(n - 1)) * x / n
+         */
+        return lastTerm * x / n;
+    }
+
+    /*
+     * Factorial
+     */
+    public static double factorial(double x) {
+        if (x == (long)x) {
+            // Value of x is integer
+            return trueFactorial((long)x);
+        } else {
+            throw new ArithmeticException("Factorial of non-integer");
+        }
+    }
+
+    private static double trueFactorial(long x) {
+        if (x < 0) {
+            throw new ArithmeticException("Factorial of negative number");
+        }
+        // Tail-recursive
+        return trueFactorialIteration(1, x);
+    }
+
+    private static double trueFactorialIteration(double carry, long x) {
+        if (x == 0) {
+            return carry;
+        } else {
+            return trueFactorialIteration(carry * x, x - 1);
+        }
+    }
+
+    /*
+     * Natural logarithm
+     */
+    public static double ln(double x) {
+        if (x <= 0) {
+            throw new ArithmeticException("ln(x) not real for x <= 0");
+        }
+        double previousResult = 1;
+        double result = lnFixedPointIteration(x, previousResult);
+        int numIterations = 1; 
+        while (abs(result - previousResult) > EPSILON_REL * result) {
+            if (numIterations++ > MAX_ITERATIONS) {
+                throw new ArithmeticException(String.format("ln(%f) did not converge", x));
+            }
+            previousResult = result;
+            result = lnFixedPointIteration(x, result);
+        }
+        return result;
+    }
+
+    private static double lnFixedPointIteration(double x, double currentEstimate) {
+        return currentEstimate + 2 * (x - exp(currentEstimate)) / (x + exp(currentEstimate));
     }
 }

--- a/src/main/java/com/ejthomas/backend/Calculator.java
+++ b/src/main/java/com/ejthomas/backend/Calculator.java
@@ -2,7 +2,7 @@ package com.ejthomas.backend;
 
 public class Calculator {
 
-    public final static double EPSILON_REL = 1e-10;
+    public final static double EPSILON_REL = 1e-15;
     public final static int MAX_ITERATIONS = 1_000_000;
 
     /*

--- a/src/main/java/com/ejthomas/backend/Calculator.java
+++ b/src/main/java/com/ejthomas/backend/Calculator.java
@@ -26,17 +26,13 @@ public class Calculator {
          * - base == 0, exponent < 0
          * - exponent > 0
          */
-        if (exponent == 0) {
-            if (base == 0) {
-                throw new ArithmeticException("0/0 is undefined");
-            } else {
-                return 1;
-            }
+        if (base == 0 && exponent <= 0) {
+            throw new ArithmeticException(String.format("%f^%d is undefined", base, exponent));
         }
-        if (exponent < 0) {
-            if (base == 0) {
-                throw new ArithmeticException("1/0 is undefined");
-            }
+        if (base != 0 && exponent == 0) {
+            return 1;
+        }
+        if (base != 0 && exponent < 0) {
             return powBySquaring(1 / base, -exponent);
         }
         // Use tail-recursive iteration

--- a/src/main/java/com/ejthomas/backend/Parser.java
+++ b/src/main/java/com/ejthomas/backend/Parser.java
@@ -195,7 +195,12 @@ public class Parser {
 
     private double div(double num1) {
         // TODO: check for overflow before evaluating
-        return num1 / getFactor();
+        double num2 = getFactor();
+        if (num2 == 0.0) {
+            error("Division by 0");
+            return 0;
+        }
+        return num1 / num2;
     }
 
     private double pow(double base) {

--- a/src/main/java/com/ejthomas/frontend/Window.java
+++ b/src/main/java/com/ejthomas/frontend/Window.java
@@ -95,6 +95,9 @@ public class Window extends JFrame {
         // zero goes last to match typical numpad
         numberPanel.add(new InputButton("0", this));
 
+        // Decimal point button
+        numberPanel.add(new InputButton(".", this));
+
         // Previous answer button
         JButton lastAnswerButton = new JButton("ANS");
         lastAnswerButton.addActionListener(new ActionListener(){
@@ -197,9 +200,16 @@ public class Window extends JFrame {
         Parser parser = new Parser(getInput());
         parser.evaluate();
         if (parser.isEvaluated()) {
-            String answer = String.valueOf(parser.getResult());
-            setAnswer(answer);
-            lastAnswer = answer;
+            double result = parser.getResult();
+            if (result == (int)result) {
+                String answer = String.valueOf((int)result);
+                setAnswer(answer);
+                lastAnswer = answer;
+            } else {
+                String answer = String.valueOf(result);
+                setAnswer(answer);
+                lastAnswer = answer;
+            }
         } else {
             setAnswer("Syntax Error");
         }

--- a/src/main/java/com/ejthomas/frontend/Window.java
+++ b/src/main/java/com/ejthomas/frontend/Window.java
@@ -1,6 +1,7 @@
 package com.ejthomas.frontend;
 
 import javax.swing.*;
+import javax.swing.border.Border;
 
 import com.ejthomas.backend.Parser;
 
@@ -16,6 +17,10 @@ public class Window extends JFrame {
     protected JTextField inputField;
     protected JLabel answerLabel;
     private String lastAnswer = "";
+    private final JPanel displayPanel;
+    private final JPanel numberPanel;
+    private final JPanel operationPanel;
+    private final JPanel lowerPanel;
 
     public static void main(String[] args) {
         Window window = new Window("SeeYouL8r Calculator");
@@ -27,23 +32,23 @@ public class Window extends JFrame {
         super(name);
 
         // Display panel
-        JPanel displayPanel = createDisplayPanel();
+        displayPanel = createDisplayPanel();
         this.getContentPane().add(displayPanel, BorderLayout.PAGE_START);
 
         // Lower panel
-        JPanel lowerPanel = new JPanel();
+        lowerPanel = new JPanel();
         lowerPanel.setLayout(new BoxLayout(lowerPanel, BoxLayout.LINE_AXIS));
         this.getContentPane().add(lowerPanel, BorderLayout.CENTER);
 
         // Number panel
-        JPanel numberPanel = createNumberPanel();
+        numberPanel = createNumberPanel();
         lowerPanel.add(numberPanel);
 
         // Separator
         lowerPanel.add(Box.createHorizontalStrut(30));
 
         // Operation panel
-        JPanel operationPanel = createOperationPanel();
+        operationPanel = createOperationPanel();
         lowerPanel.add(operationPanel);
 
 
@@ -72,15 +77,19 @@ public class Window extends JFrame {
     private JPanel createDisplayPanel() {
         JPanel displayPanel = new JPanel();
         displayPanel.setLayout(new BoxLayout(displayPanel, BoxLayout.LINE_AXIS));
+        displayPanel.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
 
         inputField = new JTextField();
-        inputField.setPreferredSize(new Dimension(100, 50));
+        inputField.setPreferredSize(new Dimension(0, 50));
         displayPanel.add(inputField);
 
+        // displayPanel.add(Box.createHorizontalStrut(20));
 
         answerLabel = new JLabel();
-        answerLabel.setPreferredSize(new Dimension(100, 50));
+        // answerLabel.setPreferredSize(new Dimension(100, 50));
+        // answerLabel.setMinimumSize(new Dimension(200, 50));
         displayPanel.add(answerLabel);
+        // displayPanel.add(Box.createHorizontalStrut(20), 1);
         return displayPanel;
     }
 
@@ -194,6 +203,8 @@ public class Window extends JFrame {
     public void clearAction() {
         setInput("");
         setAnswer("");
+        // Remove extra space between input and answer fields
+        displayPanel.remove(1);
     }
 
     public void equalsAction() {
@@ -210,9 +221,13 @@ public class Window extends JFrame {
                 setAnswer(answer);
                 lastAnswer = answer;
             }
+        } else if (parser.isInErrorState()) {
+            setAnswer(parser.getLastError());
         } else {
-            setAnswer("Syntax Error");
+            setAnswer("Unknown Error");
         }
+        // Increase space between input and answer fields
+        displayPanel.add(Box.createHorizontalStrut(20), 1); 
     }
 
     public void lastAnswerAction() {

--- a/src/main/java/com/ejthomas/frontend/Window.java
+++ b/src/main/java/com/ejthomas/frontend/Window.java
@@ -1,7 +1,6 @@
 package com.ejthomas.frontend;
 
 import javax.swing.*;
-import javax.swing.border.Border;
 
 import com.ejthomas.backend.Parser;
 

--- a/src/test/java/com/ejthomas/backend/CalculatorTest.java
+++ b/src/test/java/com/ejthomas/backend/CalculatorTest.java
@@ -50,8 +50,8 @@ public class CalculatorTest {
 
     @Test
     public void givenPositiveBaseAndNonIntExp_whenPow_thenCalculatesPower() {
-        Assertions.assertTrue(Calculator.abs(2.82842712475 - Calculator.pow(8, 0.5)) < Calculator.EPSILON_REL * 2.82842712475);
-        Assertions.assertTrue(Calculator.abs(36912.0142177 - Calculator.pow(13, 4.1)) < Calculator.EPSILON_REL * 36912.0142177);
+        Assertions.assertTrue(Calculator.abs(2.828427124746190 - Calculator.pow(8, 0.5)) < Calculator.EPSILON_REL * 2.828427124746190);
+        Assertions.assertTrue(Calculator.abs(36912.014217721338 - Calculator.pow(13, 4.1)) < Calculator.EPSILON_REL * 36912.014217721338);
     }
 
     @Test
@@ -78,9 +78,9 @@ public class CalculatorTest {
      */
     @Test
     public void givenPositiveDouble_whenExp_thenConverges() {
-        Assertions.assertTrue(Calculator.abs(2.71828182846 - Calculator.exp(1)) < Calculator.EPSILON_REL * 2.71828182846);
-        Assertions.assertTrue(Calculator.abs(485165195.40979 - Calculator.exp(20)) < Calculator.EPSILON_REL * 485165195.40979);
-        Assertions.assertTrue(Calculator.abs(5184705528587070000000.0 - Calculator.exp(50)) < Calculator.EPSILON_REL * 5184705528587070000000.0);
+        Assertions.assertTrue(Calculator.abs(2.7182818284590452 - Calculator.exp(1)) < Calculator.EPSILON_REL * 2.7182818284590452);
+        Assertions.assertTrue(Calculator.abs(485165195.40979028 - Calculator.exp(20)) < Calculator.EPSILON_REL * 485165195.40979028);
+        Assertions.assertTrue(Calculator.abs(5184705528587072464087.0 - Calculator.exp(50)) < Calculator.EPSILON_REL * 5184705528587072464087.0);
     }
 
     @Test
@@ -90,9 +90,9 @@ public class CalculatorTest {
 
     @Test
     public void givenNegativeDouble_whenExp_thenConverges() {
-        Assertions.assertTrue(Calculator.abs(0.367879441171 - Calculator.exp(-1)) < Calculator.EPSILON_REL * 0.367879441171);
-        Assertions.assertTrue(Calculator.abs(2.06115362244e-9 - Calculator.exp(-20)) < Calculator.EPSILON_REL * 2.06115362244e-9);
-        Assertions.assertTrue(Calculator.abs(1.92874984796e-22 - Calculator.exp(-50)) < Calculator.EPSILON_REL * 1.92874984796e-22);
+        Assertions.assertTrue(Calculator.abs(0.36787944117144232 - Calculator.exp(-1)) < Calculator.EPSILON_REL * 0.36787944117144232);
+        Assertions.assertTrue(Calculator.abs(2.06115362243855783e-9 - Calculator.exp(-20)) < Calculator.EPSILON_REL * 2.06115362243855783e-9);
+        Assertions.assertTrue(Calculator.abs(1.92874984796391778e-22 - Calculator.exp(-50)) < Calculator.EPSILON_REL * 1.92874984796391778e-22);
     }
 
     /*
@@ -127,8 +127,8 @@ public class CalculatorTest {
 
     @Test
     public void givenPositive_whenLn_thenConverges() {
-        Assertions.assertTrue(Calculator.abs(0.69314718056 - Calculator.ln(2)) < Calculator.EPSILON_REL * 0.69314718056);
-        Assertions.assertTrue(Calculator.abs(6.23832462504 - Calculator.ln(512)) < Calculator.EPSILON_REL * 6.23832462504);
-        Assertions.assertTrue(Calculator.abs(472.029944064 - Calculator.ln(1e205)) < Calculator.EPSILON_REL * 472.029944064);
+        Assertions.assertTrue(Calculator.abs(0.69314718055994531 - Calculator.ln(2)) < Calculator.EPSILON_REL * 0.69314718055994531);
+        Assertions.assertTrue(Calculator.abs(6.2383246250395078 - Calculator.ln(512)) < Calculator.EPSILON_REL * 6.2383246250395078);
+        Assertions.assertTrue(Calculator.abs(472.02994406377937 - Calculator.ln(1e205)) < Calculator.EPSILON_REL * 472.02994406377937);
     }
 }

--- a/src/test/java/com/ejthomas/backend/CalculatorTest.java
+++ b/src/test/java/com/ejthomas/backend/CalculatorTest.java
@@ -4,9 +4,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
 
 public class CalculatorTest {
+    
     /*
-     * Functions to test:
-     * - pow()
+     * pow
      */
     @Test
     public void givenPosIntBaseAndExp_whenPow_thenCalculatesPower() {
@@ -35,17 +35,100 @@ public class CalculatorTest {
     }
 
     @Test
-    public void givenPosIntBaseAndNegativeIntExp_whenPow_thenPerformsIntDivide() {
-        // This is only correct for integer arithmetic
-        Assertions.assertEquals(0, Calculator.pow(2, -1));
+    public void givenPosIntBaseAndNegativeIntExp_whenPow_thenPerformsDivide() {
+        Assertions.assertEquals(0.5, Calculator.pow(2, -1));
         Assertions.assertEquals(1, Calculator.pow(1, -1));
         Assertions.assertEquals(1, Calculator.pow(1, -3));
-        Assertions.assertEquals(0, Calculator.pow(3, -2));
+        Assertions.assertEquals(1.0/9.0, Calculator.pow(3, -2));
     }
 
     @Test
     public void givenNegativeIntBaseAndPositiveIntExp_whenPow_thenCalculatesPower() {
         Assertions.assertEquals(16, Calculator.pow(-2, 4));
         Assertions.assertEquals(-27, Calculator.pow(-3, 3));
+    }
+
+    @Test
+    public void givenPositiveBaseAndNonIntExp_whenPow_thenCalculatesPower() {
+        Assertions.assertTrue(Calculator.abs(2.82842712475 - Calculator.pow(8, 0.5)) < Calculator.EPSILON_REL * 2.82842712475);
+        Assertions.assertTrue(Calculator.abs(36912.0142177 - Calculator.pow(13, 4.1)) < Calculator.EPSILON_REL * 36912.0142177);
+    }
+
+    @Test
+    public void givenNegativeBaseAndNonIntExp_whenPow_thenThrows() {
+        Assertions.assertThrows(ArithmeticException.class, () -> Calculator.pow(-3.5, 5.5));
+    }
+
+    /*
+     * abs
+     */
+
+    @Test
+    public void givenPositive_whenAbs_thenReturnsSame() {
+        Assertions.assertEquals(1.23456789, Calculator.abs(1.23456789));
+    }
+
+    @Test
+    public void givenNegative_whenAbs_thenReturnsPositive() {
+        Assertions.assertEquals(1.23456789, Calculator.abs(-1.23456789));
+    }
+
+    /*
+     * exp
+     */
+    @Test
+    public void givenPositiveDouble_whenExp_thenConverges() {
+        Assertions.assertTrue(Calculator.abs(2.71828182846 - Calculator.exp(1)) < Calculator.EPSILON_REL * 2.71828182846);
+        Assertions.assertTrue(Calculator.abs(485165195.40979 - Calculator.exp(20)) < Calculator.EPSILON_REL * 485165195.40979);
+        Assertions.assertTrue(Calculator.abs(5184705528587070000000.0 - Calculator.exp(50)) < Calculator.EPSILON_REL * 5184705528587070000000.0);
+    }
+
+    @Test
+    public void givenZero_whenExp_thenReturnsOne() {
+        Assertions.assertEquals(1, Calculator.exp(0));
+    }
+
+    @Test
+    public void givenNegativeDouble_whenExp_thenConverges() {
+        Assertions.assertTrue(Calculator.abs(0.367879441171 - Calculator.exp(-1)) < Calculator.EPSILON_REL * 0.367879441171);
+        Assertions.assertTrue(Calculator.abs(2.06115362244e-9 - Calculator.exp(-20)) < Calculator.EPSILON_REL * 2.06115362244e-9);
+        Assertions.assertTrue(Calculator.abs(1.92874984796e-22 - Calculator.exp(-50)) < Calculator.EPSILON_REL * 1.92874984796e-22);
+    }
+
+    /*
+     * factorial
+     */
+    @Test
+    public void givenPositiveNonInteger_whenFactorial_thenThrows() {
+        Assertions.assertThrows(ArithmeticException.class, () -> Calculator.factorial(7.5));
+    }
+
+    @Test
+    public void givenNegativeInteger_whenFactorial_thenThrows() {
+        Assertions.assertThrows(ArithmeticException.class, () -> Calculator.factorial(-12));
+    }
+
+    @Test
+    public void givenPositiveInteger_whenFactorial_thenEvaluates() {
+        Assertions.assertEquals(120, Calculator.factorial(5));
+        Assertions.assertEquals(1, Calculator.factorial(0));
+        Assertions.assertEquals(1, Calculator.factorial(1));
+        Assertions.assertEquals(3628800, Calculator.factorial(10));
+    }
+    
+    /*
+     * ln
+     */
+    @Test
+    public void givenNonPositive_whenLn_thenRejects() {
+        Assertions.assertThrows(ArithmeticException.class, ()->Calculator.ln(-12));
+        Assertions.assertThrows(ArithmeticException.class, ()->Calculator.ln(0));
+    }
+
+    @Test
+    public void givenPositive_whenLn_thenConverges() {
+        Assertions.assertTrue(Calculator.abs(0.69314718056 - Calculator.ln(2)) < Calculator.EPSILON_REL * 0.69314718056);
+        Assertions.assertTrue(Calculator.abs(6.23832462504 - Calculator.ln(512)) < Calculator.EPSILON_REL * 6.23832462504);
+        Assertions.assertTrue(Calculator.abs(472.029944064 - Calculator.ln(1e205)) < Calculator.EPSILON_REL * 472.029944064);
     }
 }

--- a/src/test/java/com/ejthomas/backend/ParserTest.java
+++ b/src/test/java/com/ejthomas/backend/ParserTest.java
@@ -64,11 +64,11 @@ public class ParserTest {
         Assertions.assertTrue(parser.isEvaluated());
         Assertions.assertEquals(17, parser.getResult());
 
-        // Rounding towards zero divide
+        // Floating-point divide
         parser = new Parser("49/2");
         parser.evaluate();
         Assertions.assertTrue(parser.isEvaluated());
-        Assertions.assertEquals(24, parser.getResult());
+        Assertions.assertEquals(24.5, parser.getResult());
 
         // Rejects letter at start
         parser = new Parser("A2/2");
@@ -208,7 +208,7 @@ public class ParserTest {
         parser = new Parser("10^-1");
         parser.evaluate();
         Assertions.assertTrue(parser.isEvaluated());
-        Assertions.assertEquals(0, parser.getResult());
+        Assertions.assertEquals(0.1, parser.getResult());
     }
 
     @Test
@@ -232,5 +232,33 @@ public class ParserTest {
         parser = new Parser("2^3^2");
         parser.evaluate();
         Assertions.assertEquals(512, parser.getResult());
+    }
+
+    @Test
+    public void givenInvalidPower_whenEvaluate_thenRejects() {
+        Parser parser = new Parser("0^-2");
+        parser.evaluate();
+        Assertions.assertFalse(parser.isEvaluated());
+        Assertions.assertTrue(parser.isInErrorState());
+
+        parser = new Parser("0^0");
+        parser.evaluate();
+        Assertions.assertFalse(parser.isEvaluated());
+        Assertions.assertTrue(parser.isInErrorState());
+    }
+
+    @Test
+    public void givenDecimal_whenEvaluate_thenReturnsDouble() {
+        Parser parser = new Parser("4.9");
+        parser.evaluate();
+        Assertions.assertEquals(4.9, parser.getResult());
+
+        parser = new Parser("2.5*3");
+        parser.evaluate();
+        Assertions.assertEquals(7.5, parser.getResult());
+
+        parser = new Parser("3.1*1.4");
+        parser.evaluate();
+        Assertions.assertEquals(4.34, parser.getResult());
     }
 }

--- a/src/test/java/com/ejthomas/frontend/WindowTest.java
+++ b/src/test/java/com/ejthomas/frontend/WindowTest.java
@@ -37,9 +37,9 @@ public class WindowTest {
     public void equalsAction() {
         Window window = new Window("Window");
 
-        // Syntax error if empty
+        // Error message if empty
         window.equalsAction();
-        Assertions.assertEquals("Syntax Error", window.getAnswer());
+        Assertions.assertEquals("Expected non-empty", window.getAnswer());
 
         // Sets answer correctly when input field valid
         window.setInput("15*2");

--- a/src/test/java/com/ejthomas/frontend/WindowTest.java
+++ b/src/test/java/com/ejthomas/frontend/WindowTest.java
@@ -34,17 +34,26 @@ public class WindowTest {
     }
 
     @Test
-    public void equalsAction() {
+    public void givenEmptyInput_whenEqualsAction_thenAnswerIsError() {
         Window window = new Window("Window");
-
-        // Error message if empty
         window.equalsAction();
         Assertions.assertEquals("Expected non-empty", window.getAnswer());
+    }
 
-        // Sets answer correctly when input field valid
+    @Test
+    public void givenValidInput_whenEqualsAction_thenIntegerAnswerIsCorrect() {
+        Window window = new Window("Window");
         window.setInput("15*2");
         window.equalsAction();
         Assertions.assertEquals("30", window.getAnswer());
+    }
+
+    @Test
+    public void givenValidInput_whenEqualsAction_thenDoubleAnswerIsCorrect() {
+        Window window = new Window("Window");
+        window.setInput("1.8*3");
+        window.equalsAction();
+        Assertions.assertEquals("5.4", window.getAnswer());
     }
 
     @Test


### PR DESCRIPTION
Closes #8, #9, #11 

The calculations behind the scenes are now performed in double-precision floating-point arithmetic using the `double` type. This permits non-integer input values and results. When the answer is an integer, it is converted to an integer type for display. Moving to floating-point calculations completes the implementation of exponentiation, including fractional indices. This can be used to calculate square roots and higher roots.